### PR TITLE
fix regex (#3)

### DIFF
--- a/htmlparser/helpers/clean_attributes.py
+++ b/htmlparser/helpers/clean_attributes.py
@@ -8,6 +8,6 @@ import re
 
 def clean_attributes(input: str):
     try:
-        return re.findall(r'(.*.css|.*.jsx|.*.js)', input)[0]
+        return re.findall(r'(.*\.css|.*\.jsx|.*\.js)', input)[0]
     except IndexError:
         return ""


### PR DESCRIPTION
This PR fixes the regex that clears out any other attributes in the provided string, that selects other attributes too.
Change of code:
https://github.com/weblit/html-parser/blob/7a12f3d20575cbabfdb3c9e44de48827ac6632c4/htmlparser/helpers/clean_attributes.py#L11
